### PR TITLE
feat: add watcher list to issues

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,13 @@
+[*]
+charset = utf-8
+# Unix-style newlines with a newline ending every file
+end_of_line = lf
+# insert_final_newline = true
+insert_final_newline = false
+indent_style = space
+indent_size = 4
+trim_trailing_whitespace = true
+max_line_length = 160
+
+[*.java]
+continuation_indent_size = 0

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Instructions:
 
 - Build the code
 ```bash
-mvn clean package 
+mvn clean package
 ```
 
 ### Release definition
@@ -35,18 +35,19 @@ new release cycle.
 The `release.yml` file lives in the `snowdrop/spring-boot-bom` repository right next to the `pom.xml` file so that they
 can evolve concurrently as needed and be kept in sync. This file should be updated each time the team starts working
  on a new release.
- 
+
 An example of such `release.yml` can be found at: https://github.com/metacosm/spring-boot-bom/blob/release-integration/release.yml
 
 ### Create JIRA stakeholder request issues
 
-To create a bulk of issues for a component/starter which are blocking a JIRA Issue release, use the following command: 
+To create a bulk of issues for a component/starter which are blocking a JIRA Issue release, use the following command:
 ```bash
 java -jar target/uber-issues-manager-1.0-SNAPSHOT.jar \
     -user JBOSS_JIRA_USER \
-    -password JBOSS_JIRA_PWD 
+    -password JBOSS_JIRA_PWD \
     -action create-component \
-    -git <github org>/<github repo>/<git reference: branch, tag, hash> 
+    -watcher_list john,doe \
+    -git <github org>/<github repo>/<git reference: branch, tag, hash>
 ```
 
 This will parse the `release.yml` file found at the specified git reference, retrieve all the defined components
@@ -57,16 +58,16 @@ This will parse the `release.yml` file found at the specified git reference, ret
 Each component is identified by its associated JIRA project name (which is used to create the corresponding JIRA
 request) and a set of properties used to identify which artifacts are linked to this particular component. The
 name of the component's properties follow the name version properties defined in the POM. For example, for Hibernate,
-the version property is named `hibernate.version` and the associated component property is named `hibernate` 
+the version property is named `hibernate.version` and the associated component property is named `hibernate`
 (`issues-manager` takes care of matching that property to the one used in the POM). If we also want to associate
 other properties to the same component, we can add more. For example, the Hibernate component is associated with
 the `hibernate-validator` property.
-       
-**IMPORTANT**: 
+
+**IMPORTANT**:
 
 ### Link JIRA issues to a parent
 
-To Link different issues to a JIRA issue using as relation type `Is Blocked By`, then execute the following command:  
+To Link different issues to a JIRA issue using as relation type `Is Blocked By`, then execute the following command:
 ```bash
 java -jar target/uber-issues-manager-1.0-SNAPSHOT.jar \
     -user JBOSS_JIRA_USER \
@@ -75,7 +76,7 @@ java -jar target/uber-issues-manager-1.0-SNAPSHOT.jar \
     -cfg etc/release.yaml \
     -action link \
     -issue ENTSBT-xxx \
-    -to_issue EAP-yyy 
+    -to_issue EAP-yyy
 ```
 
 The `to_issue` parameter represents the issue which currently blocks the release issue referenced by the parameter `issue`.
@@ -92,7 +93,7 @@ To clone a Release issue and their sub-tasks
     -action clone \
     -issue ENTSBT-ddd
 ```
- 
+
 ## HTTP Request to get or create JIRA tickets
 
 Atlassian REST API v2 doc: https://docs.atlassian.com/software/jira/docs/api/REST/8.10.0/

--- a/src/main/java/dev/snowdrop/jira/atlassian/Args.java
+++ b/src/main/java/dev/snowdrop/jira/atlassian/Args.java
@@ -35,4 +35,7 @@ public class Args {
 
     @Parameter(names = "-git", description = "GitHub reference")
     public String gitRef;
+
+    @Parameter(names = "-watcher_list", description = "JIRA Watcher List CSV")
+    public String watcherList;
 }

--- a/src/main/java/dev/snowdrop/jira/atlassian/ReleaseService.java
+++ b/src/main/java/dev/snowdrop/jira/atlassian/ReleaseService.java
@@ -13,148 +13,155 @@ import dev.snowdrop.jira.atlassian.model.IssueSource;
 import dev.snowdrop.jira.atlassian.model.Release;
 import org.jboss.logging.Logger;
 
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.util.Arrays;
 import java.util.stream.StreamSupport;
 
 import static dev.snowdrop.jira.atlassian.Utility.*;
 
 public class ReleaseService extends Service {
-	private static final Logger LOG = Logger.getLogger(ReleaseService.class);
-	public static final String RELEASE_TICKET_TEMPLATE = "ENTSBT-323";
+    public static final String RELEASE_TICKET_TEMPLATE = "ENTSBT-323";
+    private static final Logger LOG = Logger.getLogger(ReleaseService.class);
 
-	public static void startRelease(Args args) {
-		Release release = Release.createFromGitRef(gitRefOrFail(args));
+    public static void startRelease(Args args) {
+        Release release = Release.createFromGitRef(gitRefOrFail(args));
 
-		// first check if we already have a release ticket, in which case we don't need to clone the template
-		final String releaseTicket = release.getJiraKey();
-		if (!Utility.isStringNullOrBlank(releaseTicket)) {
-			final IssueRestClient cl = restClient.getIssueClient();
-			cl.getIssue(releaseTicket)
-					// set the JIRA key of the release if not already set
-					.done(i -> LOG.infof("Release ticket %s already exists, skipping cloning step", releaseTicket))
-					// if the issue doesn't exist, create it by cloning the template ticket, which should set the JIRA key
-					.fail(e -> clone(release, RELEASE_TICKET_TEMPLATE));
-		} else {
-			// no release ticket was specified, clone
-			clone(release, RELEASE_TICKET_TEMPLATE);
-		}
-		createComponentRequests(release);
-	}
+        // first check if we already have a release ticket, in which case we don't need to clone the template
+        final String releaseTicket = release.getJiraKey();
+        if (!Utility.isStringNullOrBlank(releaseTicket)) {
+            final IssueRestClient cl = restClient.getIssueClient();
+            cl.getIssue(releaseTicket)
+            // set the JIRA key of the release if not already set
+            .done(i -> LOG.infof("Release ticket %s already exists, skipping cloning step", releaseTicket))
+            // if the issue doesn't exist, create it by cloning the template ticket, which should set the JIRA key
+            .fail(e -> clone(release, RELEASE_TICKET_TEMPLATE, args.watcherList));
+        } else {
+            // no release ticket was specified, clone
+            clone(release, RELEASE_TICKET_TEMPLATE, args.watcherList);
+        }
+        createComponentRequests(release, args.watcherList);
+    }
 
-	private static String gitRefOrFail(Args args) {
-		if (args.gitRef == null) {
-			throw new IllegalArgumentException("Must provide a Git reference to retrieve release.yml from");
-		}
-		return args.gitRef;
-	}
+    private static String gitRefOrFail(Args args) {
+        if (args.gitRef == null) {
+            throw new IllegalArgumentException("Must provide a Git reference to retrieve release.yml from");
+        }
+        return args.gitRef;
+    }
 
-	/*
-	 * Clone an existing JIRA issue to create the Release issue
-	 * If subtasks exist, then the corresponding issues will be created and linked to the release issue
-	 *
-	 * If CVEs have been defined within the Release YAML, then we will link them also as blocking links to the release issue
-	 *
-	 */
-	public static void cloneIssue(Args args) {
-		final String toCloneFrom = args.issue != null ? args.issue : RELEASE_TICKET_TEMPLATE;
-		Release release = Release.createFromGitRef(gitRefOrFail(args));
+    /*
+     * Clone an existing JIRA issue to create the Release issue
+     * If subtasks exist, then the corresponding issues will be created and linked to the release issue
+     *
+     * If CVEs have been defined within the Release YAML, then we will link them also as blocking links to the release issue
+     *
+     */
+    public static void cloneIssue(Args args) {
+        final String toCloneFrom = args.issue != null ? args.issue : RELEASE_TICKET_TEMPLATE;
+        Release release = Release.createFromGitRef(gitRefOrFail(args));
 
-		clone(release, toCloneFrom);
-	}
+        clone(release, toCloneFrom, args.watcherList);
+    }
 
-	private static void clone(Release release, String toCloneFrom) {
-		final IssueRestClient cl = restClient.getIssueClient();
-		Issue issue = cl.getIssue(toCloneFrom).claim();
-		// Create the cloned task
-		IssueInputBuilder iib = new IssueInputBuilder();
-		iib.setProjectKey(issue.getProject().getKey());
-		iib.setDescription(issue.getDescription());
-		iib.setSummary(release.getLongVersionName());
-		iib.setIssueTypeId(issue.getIssueType().getId());
-		IssueInput ii = iib.build();
-		BasicIssue clonedIssue = cl.createIssue(ii).claim();
-		final String clonedIssueKey = clonedIssue.getKey();
-		LOG.infof("Issue cloned: %s", getURLFor(clonedIssueKey));
+    private static void clone(Release release, String toCloneFrom, final String watcherList) {
+        final IssueRestClient cl = restClient.getIssueClient();
+        Issue issue = cl.getIssue(toCloneFrom).claim();
+        // Create the cloned task
+        IssueInputBuilder iib = new IssueInputBuilder();
+        iib.setProjectKey(issue.getProject().getKey());
+        iib.setDescription(issue.getDescription());
+        iib.setSummary(release.getLongVersionName());
+        iib.setIssueTypeId(issue.getIssueType().getId());
+        IssueInput ii = iib.build();
+        BasicIssue clonedIssue = cl.createIssue(ii).claim();
+        final String clonedIssueKey = clonedIssue.getKey();
+        addWatchers(clonedIssueKey, watcherList);
+        LOG.infof("Issue cloned: %s", getURLFor(clonedIssueKey));
 
-		try {
-			cl.linkIssue(new LinkIssuesInput(clonedIssueKey, toCloneFrom, "Cloners")).claim();
-		} catch (Exception e) {
-			LOG.error("Couldn't link " + clonedIssueKey + " as clone of " + toCloneFrom, e);
-		}
+        try {
+            cl.linkIssue(new LinkIssuesInput(clonedIssueKey, toCloneFrom, "Cloners")).claim();
+        } catch (Exception e) {
+            LOG.error("Couldn't link " + clonedIssueKey + " as clone of " + toCloneFrom, e);
+        }
 
-		// Check if CVEs exist within the Release and link them to the new release ticket created
-		for (dev.snowdrop.jira.atlassian.model.Issue cve : release.getCves()) {
-			linkIssue(clonedIssueKey, cve.getProject() + "-" + cve.getKey());
-		}
+        // Check if CVEs exist within the Release and link them to the new release ticket created
+        for (dev.snowdrop.jira.atlassian.model.Issue cve : release.getCves()) {
+            linkIssue(clonedIssueKey, cve.getProject() + "-" + cve.getKey());
+        }
 
-		// Get the list of the sub-tasks
-		Iterable<Subtask> subTasks = issue.getSubtasks();
-		for (Subtask subtask : subTasks) {
-			// Fetch the SubTask from the server as the subTask object dont contain the assignee :-(
-			Issue fetchSubTask = cl.getIssue(subtask.getIssueKey()).claim();
-			if (fetchSubTask != null) {
-				// Create a sub-task that we will link to the parent
-				iib = new IssueInputBuilder();
-				iib.setProjectKey(issue.getProject().getKey());
-				iib.setSummary(subtask.getSummary());
-				iib.setIssueTypeId(subtask.getIssueType().getId());
-				if (fetchSubTask.getAssignee() != null) {
-					iib.setAssignee(fetchSubTask.getAssignee());
-				}
-				iib.setFieldValue("parent", ComplexIssueInputFieldValue.with("key", clonedIssueKey));
-				ii = iib.build();
-				BasicIssue subTaskIssue = cl.createIssue(ii).claim();
-				LOG.infof("Sub task issue cloned: %s", subTaskIssue.getKey());
-			}
-		}
+        // Get the list of the sub-tasks
+        Iterable<Subtask> subTasks = issue.getSubtasks();
+        for (Subtask subtask : subTasks) {
+            // Fetch the SubTask from the server as the subTask object dont contain the assignee :-(
+            Issue fetchSubTask = cl.getIssue(subtask.getIssueKey()).claim();
+            if (fetchSubTask != null) {
+                // Create a sub-task that we will link to the parent
+                iib = new IssueInputBuilder();
+                iib.setProjectKey(issue.getProject().getKey());
+                iib.setSummary(subtask.getSummary());
+                iib.setIssueTypeId(subtask.getIssueType().getId());
+                if (fetchSubTask.getAssignee() != null) {
+                    iib.setAssignee(fetchSubTask.getAssignee());
+                }
+                iib.setFieldValue("parent", ComplexIssueInputFieldValue.with("key", clonedIssueKey));
+                ii = iib.build();
+                BasicIssue subTaskIssue = cl.createIssue(ii).claim();
+                addWatchers(subTaskIssue.getKey(), watcherList);
+                LOG.infof("Sub task issue cloned: %s", subTaskIssue.getKey());
+            }
+        }
 
-		// set the JIRA key on the release for further processing
-		release.setJiraKey(clonedIssueKey);
-	}
+        // set the JIRA key on the release for further processing
+        release.setJiraKey(clonedIssueKey);
+    }
 
-	public static void createComponentIssues(Args args) {
-		final Release release = Release.createFromGitRef(gitRefOrFail(args));
-		createComponentRequests(release);
-	}
+    public static void createComponentIssues(Args args) {
+        final Release release = Release.createFromGitRef(gitRefOrFail(args));
+        createComponentRequests(release, args.watcherList);
+    }
 
-	private static void createComponentRequests(Release release) {
-		final IssueRestClient cl = restClient.getIssueClient();
-		final String jiraKey = release.getJiraKey();
+    private static void createComponentRequests(Release release, final String watcherList) {
+        final IssueRestClient cl = restClient.getIssueClient();
+        final String jiraKey = release.getJiraKey();
 
-		for (Component component : release.getComponents()) {
-			var issue = getIssueInput(component);
-			var componentIssue = cl.createIssue(issue).claim();
-			LOG.infof("Issue %s created successfully", getURLFor(componentIssue.getKey()));
+        for (Component component : release.getComponents()) {
+            var issue = getIssueInput(component);
+            var componentIssue = cl.createIssue(issue).claim();
+            addWatchers(componentIssue.getKey(), watcherList);
+            LOG.infof("Issue %s created successfully", getURLFor(componentIssue.getKey()));
 
-			/*
-			 * If the Release jira key field is not null, then we will link the newly component/starter created Issue to the
-			 * release issue
-			 */
-			if (jiraKey != null) {
-				linkIssue(jiraKey, componentIssue.getKey());
-			}
+            /*
+             * If the Release jira key field is not null, then we will link the newly component/starter created Issue to the
+             * release issue
+             */
+            if (jiraKey != null) {
+                linkIssue(jiraKey, componentIssue.getKey());
+            }
 
-			// if component also defines a product field, then we should create a ticket for the associated product team
-			// and link it to the component request
-			final var product = component.getProduct();
-			if (product != null) {
-				issue = getIssueInput(product);
-				var productIssue = cl.createIssue(issue).claim();
-				LOG.infof("Product Issue %s created successfully for %s component", getURLFor(productIssue.getKey()),
-						component.getName());
-				// link the newly created product issue with our component issue
-				linkIssue(componentIssue.getKey(), productIssue.getKey());
-			}
-		}
-	}
+            // if component also defines a product field, then we should create a ticket for the associated product team
+            // and link it to the component request
+            final var product = component.getProduct();
+            if (product != null) {
+                issue = getIssueInput(product);
+                var productIssue = cl.createIssue(issue).claim();
+                addWatchers(productIssue.getKey(), watcherList);
+                LOG.infof("Product Issue %s created successfully for %s component", getURLFor(productIssue.getKey()),
+                component.getName());
+                // link the newly created product issue with our component issue
+                linkIssue(componentIssue.getKey(), productIssue.getKey());
+            }
+        }
+    }
 
-	private static IssueInput getIssueInput(IssueSource source) {
-		IssueInputBuilder iib = new IssueInputBuilder();
-		final var jira = source.getJira();
-		iib.setProjectKey(jira.getProject());
-		iib.setSummary(source.getTitle());
-		iib.setDescription(source.getDescription());
-		iib.setIssueTypeId(jira.getIssueTypeId());
-		iib.setDueDate(toDateTime(source.getParent().getSchedule().getDueDate()));
+    private static IssueInput getIssueInput(IssueSource source) {
+        IssueInputBuilder iib = new IssueInputBuilder();
+        final var jira = source.getJira();
+        iib.setProjectKey(jira.getProject());
+        iib.setSummary(source.getTitle());
+        iib.setDescription(source.getDescription());
+        iib.setIssueTypeId(jira.getIssueTypeId());
+        iib.setDueDate(toDateTime(source.getParent().getSchedule().getDueDate()));
                 /*
                  TODO: To be investigated
 
@@ -167,10 +174,25 @@ public class ReleaseService extends Service {
                  iib.setFieldValue(TARGET_RELEASE_CUSTOMFIELD_ID,setTargetRelease());
                 */
 
-		return iib.build();
-	}
+        return iib.build();
+    }
 
-	private static long CollectionSize(Iterable<Subtask> data) {
-		return StreamSupport.stream(data.spliterator(), false).count();
-	}
+    private static long CollectionSize(Iterable<Subtask> data) {
+        return StreamSupport.stream(data.spliterator(), false).count();
+    }
+
+    private static void addWatchers(final String issueKey, final String watcherList) {
+        final IssueRestClient cl = restClient.getIssueClient();
+        try {
+            final URI jiraUri = new URI(JIRA_ISSUES_API + "issue/" + issueKey + "/watchers");
+            if (watcherList != null && watcherList.length() > 0) {
+                Arrays.asList(watcherList.split(",")).forEach(associate -> {
+                    LOG.debug("associate: " + associate);
+                    cl.addWatcher(jiraUri, associate).claim();
+                });
+            }
+        } catch (URISyntaxException e) {
+            LOG.error("Error adding wather: " + e.getMessage());
+        }
+    }
 }


### PR DESCRIPTION
New `-watcher_list` argument containing a JIRA ID CSV that, when informed, will add these IDs as watchers of all created JIRA issues.