### PR TITLE
fix: process stops when adding invalid user as watcher

### DIFF
--- a/src/main/java/dev/snowdrop/release/services/IssueService.java
+++ b/src/main/java/dev/snowdrop/release/services/IssueService.java
@@ -9,6 +9,7 @@ import javax.inject.Inject;
 
 import com.atlassian.jira.rest.client.api.IssueRestClient;
 import com.atlassian.jira.rest.client.api.JiraRestClient;
+import com.atlassian.jira.rest.client.api.RestClientException;
 import com.atlassian.jira.rest.client.api.domain.BasicIssue;
 import com.atlassian.jira.rest.client.api.domain.Issue;
 import com.atlassian.jira.rest.client.api.domain.Subtask;
@@ -191,7 +192,11 @@ public class IssueService {
             if (watchers != null && !watchers.isEmpty()) {
                 watchers.forEach(associate -> {
                     LOG.debug("associate: " + associate);
-                    cl.addWatcher(jiraUri, associate).claim();
+                    try {
+                        cl.addWatcher(jiraUri, associate).claim();
+                    } catch (RestClientException restClientException){
+                        LOG.warn("Associate " + associate +" cannot be added as watcher to " + issueKey + ". Error was the following.", restClientException);
+                    }
                 });
             }
         } catch (URISyntaxException e) {


### PR DESCRIPTION
Now if a user is invalid a WARN message is shown in the log but the process continues.

Tested by executing the clone method and adding as watcher an invalid user (`xxx`).

```bash
$  java -jar target/issues-manager-$(xpath -q -e  "/project/version/text()" pom.xml)-runner.jar     -u ${JBOSS_JIRA_USER}     -p ${JBOSS_JIRA_PWD} -w xxx     clone     ENTSBT-996     --git jacobdotcosta/spring-boot-bom/issues-mgr-test-sb-2.4.x
```

In the log the following message appears but the process doesn't stop.
```
WARN: Associate xxx cannot be added as watcher to ENTSBT-998. Error was the following.
RestClientException{statusCode=Optional.of(401), errorCollections=[ErrorCollection{status=401, errors={}, errorMessages=[The user "xxx" does not have permission to view this issue. This user will not be added to the watch list.]}]}
	at com.atlassian.jira.rest.client.internal.async.DelegatingPromise.claim(DelegatingPromise.java:45)
	at dev.snowdrop.release.services.IssueService.lambda$addWatchers$2(IssueService.java:196)
```
Closes #96 