### PR TITLE
feat: improvements to differenciate products, components and releases

### DIFF
--- a/src/main/resources/component.mustache
+++ b/src/main/resources/component.mustache
@@ -20,6 +20,8 @@ Thank you in advance for your help!
 - Please provide this information before *{{dueDate}}*, date at which we expect to start testing our new release.
 - *{color:red}Please only resolve this issue when all the information is provided below and the associated artifacts are available.{color}*
 
+More information on [this Presentation|https://docs.google.com/presentation/d/17wTMBYyNGbq8S-ita3UoPiegJEutDJuEtWI2pX7R2rE/].
+
 ===
 
 {{#artifacts}}

--- a/src/main/resources/component.mustache
+++ b/src/main/resources/component.mustache
@@ -1,15 +1,15 @@
 The Snowdrop team is pleased to inform you that we're planning to release a new Snowdrop BOM on *{{releaseDate}}*
 based on Spring Boot *{{version}}*.
 
-Some of our artifacts depend on your component and we need to know which component version we should be using for this new
+Some of our artifacts depend on your product and we need to know which product version we should be using for this new
 release.
 
 {{#starter}}
 We don't require a new release of your component as long as the artifacts you provide us with are tested and supported
-on Spring Boot *{{version}}*.
+against the following Spring Boot *{{version}}*.
 {{/starter}}
 {{#release}}
-It's important that you let us know until when your product is supported so that we can plan future releases accordingly.
+It is important that you also communicate the EOL of your product so that we can plan our future releases accordingly.
 {{/release}}
 For reference, we will support this new release until *{{endOfSupportDate}}*.
 

--- a/src/main/resources/component.mustache
+++ b/src/main/resources/component.mustache
@@ -1,12 +1,17 @@
 The Snowdrop team is pleased to inform you that we're planning to release a new Snowdrop BOM on *{{releaseDate}}*
 based on Spring Boot *{{version}}*.
 
-Some of our artifacts depend on your product and we need to know which product version we should be using for this new
+Some of our artifacts depend on your component and we need to know which component version we should be using for this new
 release.
 
-While we don't require a new release of your product as long as the artifacts you provide us with are tested and supported
-on Spring Boot *{{version}}*, it's important that you let us know until when your product is supported so that we can plan
-future releases accordingly. For reference, we will support this new release until *{{endOfSupportDate}}*.
+{{#starter}}
+We don't require a new release of your component as long as the artifacts you provide us with are tested and supported
+on Spring Boot *{{version}}*.
+{{/starter}}
+{{#release}}
+It's important that you let us know until when your product is supported so that we can plan future releases accordingly.
+{{/release}}
+For reference, we will support this new release until *{{endOfSupportDate}}*.
 
 Thank you in advance for your help!
 
@@ -18,9 +23,9 @@ Thank you in advance for your help!
 ===
 
 {{#artifacts}}
-    * +*{{name}} (upstream version is {{version}}):*+
-    - product name: [ _replace by associated product name e.g. JWS_ ]
-    - product version: [ _replace by associated project version e.g. 5.3.1_ ]
-    - supported version: [ _replace by appropriate -redhat version_ ]
-    - end of support: [ _replace by end of support date in yyyy-mm-dd format_ ]
+    * +*{{name}} (our current upstream version is {{version}}):*+
+    - component name: [ _replace by associated product name e.g. JWS_ ]
+    - upstream version: [ _replace by associated project version e.g. 5.3.1_ ]
+    - supported version: {{#release}}[ _replace by appropriate -redhat version_ ]{{/release}}{{^release}}N/A{{/release}}
+    - end of support: {{#release}}[ _replace by end of support date in yyyy-mm-dd format_ ]{{/release}}{{^release}}N/A{{/release}}
 {{/artifacts}}

--- a/src/main/resources/product.mustache
+++ b/src/main/resources/product.mustache
@@ -4,8 +4,8 @@ based on Spring Boot *{{version}}*.
 Some of our artifacts depend on your product and we need to know which product version we should be using for this new
 release.
 
-It's important that you let us know until when your product is supported so that we can plan
-future releases accordingly. For reference, we will support this new release until *{{endOfSupportDate}}*.
+It is important that you also communicate the EOL of your product so that we can plan our future releases accordingly.
+For reference, we will support this new release until *{{endOfSupportDate}}*.
 
 Thank you in advance for your help!
 

--- a/src/main/resources/product.mustache
+++ b/src/main/resources/product.mustache
@@ -4,6 +4,10 @@ based on Spring Boot *{{version}}*.
 Some of our artifacts depend on your product and we need to know which product version we should be using for this new
 release.
 
+{{#starter}}
+We don't require a new release of your component as long as the artifacts you provide us with are tested and supported
+against the following Spring Boot *{{version}}*.
+{{/starter}}
 It is important that you also communicate the EOL of your product so that we can plan our future releases accordingly.
 For reference, we will support this new release until *{{endOfSupportDate}}*.
 
@@ -18,7 +22,7 @@ Thank you in advance for your help!
 
 - product name: {{name}}
 - upstream version: [ _replace by associated project version e.g. 5.3.1_ ]
-- supported version: [ _replace by appropriate product version_ ]
+- supported version: [ _replace by appropriate -redhat version_ ]
 - end of support: [ _replace by end of support date in yyyy-mm-dd format_ ]
 {{#artifacts}}
     * +*{{name}} (our current upstream version is {{version}}):*+

--- a/src/main/resources/product.mustache
+++ b/src/main/resources/product.mustache
@@ -4,8 +4,8 @@ based on Spring Boot *{{version}}*.
 Some of our artifacts depend on your product and we need to know which product version we should be using for this new
 release.
 
-We will support this new release until *{{endOfSupportDate}}* so it's important that you let us know until when your
-product is supported so that we can plan future releases accordingly.
+It's important that you let us know until when your product is supported so that we can plan
+future releases accordingly. For reference, we will support this new release until *{{endOfSupportDate}}*.
 
 Thank you in advance for your help!
 
@@ -20,3 +20,9 @@ Thank you in advance for your help!
 - upstream version: [ _replace by associated project version e.g. 5.3.1_ ]
 - supported version: [ _replace by appropriate product version_ ]
 - end of support: [ _replace by end of support date in yyyy-mm-dd format_ ]
+{{#artifacts}}
+    * +*{{name}} (our current upstream version is {{version}}):*+
+    - component name: [ _replace by associated product name e.g. JWS_ ]
+    - upstream version: [ _replace by associated project version e.g. 5.3.1_ ]
+    - supported version: [ _replace by appropriate -redhat version_ ]
+{{/artifacts}}


### PR DESCRIPTION
These new templates create a new section for products that include both product information as well as artifact information.

When no product is present the component template differentiates between requests for starters, that require testing validation, as well as components that might or not include a release.

Closes #110