### PR TITLE
Bump quarkus 2.16.7

### DIFF
--- a/.sdkmanrc
+++ b/.sdkmanrc
@@ -1,0 +1,3 @@
+# Enable auto-env through the sdkman_auto_env config
+# Add key=value pairs of SDKs to use below
+java=11.0.16-tem

--- a/README.md
+++ b/README.md
@@ -235,10 +235,11 @@ $ java -jar target/quarkus-app/quarkus-run.jar \
 
 ## Testing
 
-The unit tests require the providing of 2 parameters to be able to login to the JIRA REST API.
+The unit tests require the providing authentication for 3 systems, GitHub, GitLab and JIRA. Whereas for GitHub and GitLab
+user and token are required, for JIRA a Personal Access Token (`pat`) will be used.
 
 ```bash
-$ ./mvnw test -Dgithub.user=${GITHUB_USER} -Dgithub.token=${GITHUB_TOKEN} -Dgitlab.user=${JBOSS_JIRA_USER} -Dgitlab.token=${GITLAB_TOKEN}
+$ ./mvnw test -Dgithub.user=${GITHUB_USER} -Dgithub.token=${GITHUB_TOKEN} -Dgitlab.user=${GITLAB_USER} -Dgitlab.token="${GITLAB_TOKEN}" -Djboss.jira.pat="${JIRA_TOKEN}"
 ```
 
 Test profiles have been implemented to differenciate unit tests and integration tests (testing against the actual JIRA API).
@@ -288,3 +289,6 @@ http --verify=no --follow --auth user:pwd https://issues.redhat.com/rest/api/2/i
 http --verify=no --follow  --auth user:pwd POST https://issues.redhat.com/rest/api/2/issue/ < jira.json
 ```
 
+## Troubleshooting
+
+For troubleshooting information check the [Troubleshooting Gudie](./troubleshooting.adoc).

--- a/pom.xml
+++ b/pom.xml
@@ -10,19 +10,17 @@
     <properties>
         <jira-rest-java-atlassian.version>5.2.4</jira-rest-java-atlassian.version>
         <fugue.version>4.7.2</fugue.version>
-        <compiler-plugin.version>3.8.1</compiler-plugin.version>
+        <compiler-plugin.version>3.10.1</compiler-plugin.version>
         <kohsuke.version>1.116</kohsuke.version>
         <markdowngenerator.version>1.3.1.1</markdowngenerator.version>
-        <maven.compiler.parameters>true</maven.compiler.parameters>
-        <maven.compiler.source>11</maven.compiler.source>
-        <maven.compiler.target>11</maven.compiler.target>
+        <maven.compiler.release>11</maven.compiler.release>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-        <quarkus-plugin.version>1.13.2.Final</quarkus-plugin.version>
-        <quarkus.platform.artifact-id>quarkus-universe-bom</quarkus.platform.artifact-id>
-        <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>1.13.2.Final</quarkus.platform.version>
-        <surefire-plugin.version>2.22.1</surefire-plugin.version>
+        <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
+        <quarkus.platform.group-id>io.quarkus.platform</quarkus.platform.group-id>
+        <quarkus.platform.version>2.16.7.Final</quarkus.platform.version>
+        <skipITs>true</skipITs>
+        <surefire-plugin.version>3.0.0</surefire-plugin.version>
     </properties>
 
     <dependencyManagement>
@@ -97,10 +95,18 @@
         </dependency>
 
         <!-- git -->
+        <!--        <dependency>-->
+        <!--            <groupId>org.eclipse.jgit</groupId>-->
+        <!--            <artifactId>org.eclipse.jgit</artifactId>-->
+        <!--        </dependency>-->
+        <!--        Aligned with Quarkus 2.16.x-->
+        <!-- https://mvnrepository.com/artifact/io.quarkiverse.jgit/quarkus-jgit -->
         <dependency>
-            <groupId>org.eclipse.jgit</groupId>
-            <artifactId>org.eclipse.jgit</artifactId>
+            <groupId>io.quarkiverse.jgit</groupId>
+            <artifactId>quarkus-jgit</artifactId>
+            <version>2.3.2</version>
         </dependency>
+
 
         <dependency>
             <groupId>org.kohsuke</groupId>
@@ -146,24 +152,29 @@
 
     <build>
         <plugins>
-                <plugin>
-                    <groupId>io.quarkus</groupId>
-                    <artifactId>quarkus-maven-plugin</artifactId>
-                    <version>${quarkus-plugin.version}</version>
-                    <extensions>true</extensions>
-                    <executions>
-                        <execution>
-                            <goals>
-                                <goal>build</goal>
-                                <goal>generate-code</goal>
-                                <goal>generate-code-tests</goal>
-                            </goals>
-                        </execution>
-                    </executions>
-                </plugin>
+            <plugin>
+                <groupId>${quarkus.platform.group-id}</groupId>
+                <artifactId>quarkus-maven-plugin</artifactId>
+                <version>${quarkus.platform.version}</version>
+                <extensions>true</extensions>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>build</goal>
+                            <goal>generate-code</goal>
+                            <goal>generate-code-tests</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
             <plugin>
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>${compiler-plugin.version}</version>
+                <configuration>
+                    <compilerArgs>
+                        <arg>-parameters</arg>
+                    </compilerArgs>
+                </configuration>
             </plugin>
             <plugin>
                 <artifactId>maven-surefire-plugin</artifactId>
@@ -175,8 +186,29 @@
                     </systemPropertyVariables>
                 </configuration>
             </plugin>
+            <plugin>
+                <artifactId>maven-failsafe-plugin</artifactId>
+                <version>${surefire-plugin.version}</version>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>integration-test</goal>
+                            <goal>verify</goal>
+                        </goals>
+                        <configuration>
+                            <systemPropertyVariables>
+                                <native.image.path>${project.build.directory}/${project.build.finalName}-runner
+                                </native.image.path>
+                                <java.util.logging.manager>org.jboss.logmanager.LogManager</java.util.logging.manager>
+                                <maven.home>${maven.home}</maven.home>
+                            </systemPropertyVariables>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
         </plugins>
     </build>
+
     <profiles>
         <profile>
             <id>native</id>
@@ -185,31 +217,8 @@
                     <name>native</name>
                 </property>
             </activation>
-            <build>
-                <plugins>
-                    <plugin>
-                        <artifactId>maven-failsafe-plugin</artifactId>
-                        <version>${surefire-plugin.version}</version>
-                        <executions>
-                            <execution>
-                                <goals>
-                                    <goal>integration-test</goal>
-                                    <goal>verify</goal>
-                                </goals>
-                                <configuration>
-                                    <systemPropertyVariables>
-                                        <native.image.path>${project.build.directory}/${project.build.finalName}-runner
-                                        </native.image.path>
-                                        <java.util.logging.manager>org.jboss.logmanager.LogManager</java.util.logging.manager>
-                                        <maven.home>${maven.home}</maven.home>
-                                    </systemPropertyVariables>
-                                </configuration>
-                            </execution>
-                        </executions>
-                    </plugin>
-                </plugins>
-            </build>
             <properties>
+                <skipITs>false</skipITs>
                 <quarkus.package.type>native</quarkus.package.type>
             </properties>
         </profile>

--- a/troubleshooting.adoc
+++ b/troubleshooting.adoc
@@ -1,0 +1,96 @@
+= Troubleshooting Guide
+A. Costa
+:icons: font
+:toc: left
+:toc-levels: 1
+
+== SSL Errors connecting to GitLab
+
+=== Problem
+
+*SSL problems* errors when executing tests.
+
+=== Symptoms
+
+Tests fail to execute with SSL related errors such as:
+
+* `https://gitlab.cee.redhat.com/snowdrop/build-configurations.git: Secure connection to https://gitlab.cee.redhat.com/snowdrop/build-configurations.git could not be established because of SSL problems`
+* `PKIX path building failed: sun.security.provider.certpath.SunCertPathBuilderException: unable to find valid certification path to requested target`
+*
+
+=== Cause
+
+The SSL certificate for `gitlab.cee.redhat.com` is not being validated by the link:https://www.eclipse.org/jgit/[Eclipse JGit] library.
+
+=== Solution
+
+Add the SSL certificate to the git configuration.
+
+Get certificate of remote server, in this case it's `gitlab.cee.redhat.com`.
+
+.Click to check the details
+[%collapsible]
+====
+
+Obtain the certificate using `openssl`.
+
+[source,bash]
+----
+openssl s_client -connect gitlab.cee.redhat.com:443
+----
+
+From the `openssl` output, get the certificate contents. The contents are located at the `Server certificate` section.
+
+The certificate contents is the whole section between the `-----BEGIN CERTIFICATE-----` and `-----END CERTIFICATE-----` lines, inclusive.
+
+[source]
+----
+-----BEGIN CERTIFICATE-----
+xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+-----END CERTIFICATE-----
+----
+
+====
+
+Store the certificate contents on a local folder, _e.g._, `$HOME/.git-certs/gitlab.redhat.com.pem`.
+
+Configure git to trust this certificate for the provided URL.
+
+.Click to check the details
+[%collapsible]
+====
+
+[source,bash]
+----
+git config --global http."https://gitlab.cee.redhat.com/".sslCAInfo $HOME/.git-certs/gitlab.redhat.com.pem
+----
+
+====
+
+Finally check the configuration has been stored.
+
+.Click to check the details
+[%collapsible]
+====
+
+Listing the git global configuration...
+
+[source,bash]
+----
+git config --global --list
+----
+
+...should present the configuration added.
+
+[source]
+----
+http.https://gitlab.cee.redhat.com/.sslcainfo=/home/janedoe/.git-certs/gitlab.redhat.com.pem
+----
+
+====


### PR DESCRIPTION
Bump Quarkus to version `2.16.7` and fix errors on the migration. 

This change is the first step to implement fix release automation.